### PR TITLE
Added template framework for applying transforms to distance maps

### DIFF
--- a/batchgeneratorsv2/transforms/base/basic_transform.py
+++ b/batchgeneratorsv2/transforms/base/basic_transform.py
@@ -26,6 +26,9 @@ class BasicTransform(abc.ABC):
 
         if data_dict.get('segmentation') is not None:
             data_dict['segmentation'] = self._apply_to_segmentation(data_dict['segmentation'], **params)
+            
+        if data_dict.get('dist_map') is not None:
+            data_dict['dist_map'] = self._apply_to_dist_map(data_dict['dist_map'], **params)
 
         if data_dict.get('keypoints') is not None:
             data_dict['keypoints'] = self._apply_to_keypoints(data_dict['keypoints'], **params)
@@ -42,6 +45,9 @@ class BasicTransform(abc.ABC):
         pass
 
     def _apply_to_segmentation(self, segmentation: torch.Tensor, **params) -> torch.Tensor:
+        pass
+
+    def _apply_to_dist_map(self, dist_map: torch.Tensor, **params) -> torch.Tensor:
         pass
 
     def _apply_to_keypoints(self, keypoints, **params):


### PR DESCRIPTION
nnUNet currently does not have a framework for loading in distance maps that were calculated offline, though I have a version of nnUNet with a modified dataloader that can do this. For full functionality, distance maps should also be cropped and transformed in a similar fashion to the image and segmentation data. The easiest way to do this is to add another key in the data dictionary called 'dist_map'. If the data has this key, then a transform can call _apply_to_dist_map. Modifying the BasicTransform class is the simplest way to add this functionality to other transforms.