### PR TITLE
fix: Update dependency fft-conv-pytorch to torch-fftconv

### DIFF
--- a/batchgeneratorsv2/transforms/nnunet/random_binary_operator.py
+++ b/batchgeneratorsv2/transforms/nnunet/random_binary_operator.py
@@ -3,7 +3,7 @@ from typing import Union, List, Tuple, Callable
 
 import numpy as np
 import torch
-from fft_conv_pytorch import fft_conv
+from torch_fftconv import fft_conv2d, fft_conv3d
 
 from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
 from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
@@ -30,11 +30,12 @@ def binary_dilation_torch(input_tensor, structure_element):
         raise ValueError("Input tensor must be 2D (X, Y) or 3D (X, Y, Z).")
 
     # Perform the convolution
-    # if num_dims == 2:  # 2D convolution
-    #     output = F.conv2d(input_tensor.unsqueeze(0).unsqueeze(0), structure_element, padding='same')
-    # elif num_dims == 3:  # 3D convolution
-    #     output = F.conv3d(input_tensor.unsqueeze(0).unsqueeze(0), structure_element, padding='same')
-    output = torch.round(fft_conv(input_tensor.unsqueeze(0).unsqueeze(0), structure_element, padding='same'), decimals=0)
+    input_tensor = input_tensor.unsqueeze(0).unsqueeze(0)
+    if num_dims == 2:  # 2D convolution
+        output = fft_conv2d(input_tensor, structure_element, padding='same')
+    elif num_dims == 3:  # 3D convolution
+        output = fft_conv3d(input_tensor, structure_element, padding='same')
+    output = torch.round(output, decimals=0)
 
     # Threshold to get binary output
     output = output > 0

--- a/batchgeneratorsv2/transforms/noise/gaussian_blur.py
+++ b/batchgeneratorsv2/transforms/noise/gaussian_blur.py
@@ -8,7 +8,7 @@ from torch.nn.functional import pad, conv3d, conv1d, conv2d
 
 from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
 from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
-from fft_conv_pytorch import fft_conv
+from torch_fftconv import fft_conv1d, fft_conv2d, fft_conv3d
 
 
 def blur_dimension(img: torch.Tensor, sigma: float, dim_to_blur: int, force_use_fft: bool = None, truncate: float = 6):
@@ -31,8 +31,9 @@ def blur_dimension(img: torch.Tensor, sigma: float, dim_to_blur: int, force_use_
 
     # Dynamically set up padding, convolution operation, and kernel shape based on the number of spatial dimensions
     conv_ops = {1: conv1d, 2: conv2d, 3: conv3d}
+    fft_conv_ops = {1: fft_conv1d, 2: fft_conv2d, 3: fft_conv3d}
     if force_use_fft is not None:
-        conv_op = conv_ops[spatial_dims] if not force_use_fft else fft_conv
+        conv_op = conv_ops[spatial_dims] if not force_use_fft else fft_conv_ops[spatial_dims]
     else:
         conv_op = conv_ops[spatial_dims]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
 dependencies = [
     "torch>=2.0.0",
     "numpy",
-    "fft-conv-pytorch",
+    "torch-fftconv",
     "batchgenerators>=0.25"
 ]
 


### PR DESCRIPTION
Hello all!

With nnUNet, we currently receive the following warning using PyTorch 2.9:
```
/home/vmiller/Work/caml/.venv/lib/python3.13/site-packages/fft_conv_pytorch/fft_conv.py:139: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /pytorch/torch/csrc/autograd/python_variable_indexing.cpp:345.)
  output = output[crop_slices].contiguous()
```

The source of this is from `fft-conv-pytorch` which is a dependency of `batchgeneratorsv2`. Unfortunately, it does not look like `fft-conv-pytorch` is being maintained. This PR has existed since July: https://github.com/fkodom/fft-conv-pytorch/pull/26

The offending code:
`fft-conv-pytorch/fft_conv_pytorch/fft_conv.py` lines 134-139`
```python
    # Remove extra padded values
    crop_slices = [slice(None), slice(None)] + [
        slice(0, (signal_size[i] - kernel.size(i) + 1), stride_[i - 2])
        for i in range(2, signal.ndim)
    ]
    output = output[crop_slices].contiguous()
```

With the help of a coworker, we found an active fork with PyPi releases where someone did fix the issue:
- https://pypi.org/project/torch-fftconv/
- https://github.com/yoyolicoris/fft-conv-pytorch/tree/f80c6973cb2155c4844e81a784e50b2777e8ac2b

The fix:
`fft-conv-pytorch/torch_fftconv/functional.py` lines 242-245
```python
    # Remove extra padded values
    index = (slice(None),) * 2 + tuple(slice(p, o + p)
                                       for p, o in zip(padding, output_size))
    output = output[index].contiguous()
```

I have updated and tested the two locations where this library is used in `batchgeneratorsv2` and updated the `pyproject.toml` to replace the out of date dependency. 