### PR TITLE
Remove Unused Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ keywords = [
 dependencies = [
     "torch>=2.0.0",
     "numpy",
-    "fft-conv-pytorch",
     "batchgenerators>=0.25"
 ]
 


### PR DESCRIPTION
This PR removes an unused dependency from the `pyproject.toml`.

@FabianIsensee is being wonderful and pulled the `fft-conv-pytorch` code into here and maintaining it. 

https://github.com/MIC-DKFZ/batchgeneratorsv2/pull/14#issuecomment-4024294239

`licensecheck` flags `fft-conv-pytorch`, which is a dependency of this repo. 