### PR TITLE
fixing bug no scaling applied when self.ignore_axes=None

### DIFF
--- a/batchgeneratorsv2/transforms/spatial/low_resolution.py
+++ b/batchgeneratorsv2/transforms/spatial/low_resolution.py
@@ -45,7 +45,7 @@ class SimulateLowResolutionTransform(ImageOnlyTransform):
                 scales = torch.Tensor([[sample_scalar(self.scale, image=data_dict['image'], channel=c, dim=None)]  * (len(shape) - 1) for c in apply_to_channel])
             else:
                 scales = torch.Tensor([[sample_scalar(self.scale, image=data_dict['image'], channel=c, dim=d) for d in range(len(shape) - 1)] for c in apply_to_channel])
-        if len(scales) > 0:
+        if len(scales) > 0 and not self.ignore_axes is None:
             scales[:, self.ignore_axes] = 1
         return {
             'apply_to_channel': apply_to_channel,


### PR DESCRIPTION
when `self.ignore_axes=None` it sets all the scales to 1 and therefore no scaling is applied after. 

Added a condition to use self.ignore_axes only if not None